### PR TITLE
feat: add custom middleware for logging and add http health check

### DIFF
--- a/handler/http/health.go
+++ b/handler/http/health.go
@@ -1,0 +1,9 @@
+package http
+
+import "net/http"
+
+func HealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"status": "OK"}`))
+}

--- a/main.go
+++ b/main.go
@@ -8,10 +8,12 @@ import (
 	"syscall"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/mocha-bot/enjot/config"
 
 	httpInternal "github.com/mocha-bot/enjot/handler/http"
 	"github.com/mocha-bot/enjot/pkg/logger"
+	middlewareInternal "github.com/mocha-bot/enjot/pkg/middleware"
 )
 
 func main() {
@@ -22,6 +24,12 @@ func main() {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
 
 	r := chi.NewRouter()
+
+	r.Use(middlewareInternal.Logger())
+	r.Use(middleware.Recoverer)
+
+	// health check handler
+	r.Get("/health", httpInternal.HealthCheck)
 
 	httpInternal.NewDummyHandler(r)
 

--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/mocha-bot/enjot/pkg/logger"
+)
+
+func Logger() func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			wrapRW := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+
+			defer func() {
+				scheme := "http"
+				if r.TLS != nil {
+					scheme = "https"
+				}
+
+				endpoint := fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI)
+
+				requestBody, _ := ioutil.ReadAll(r.Body)
+
+				if wrapRW.Status() != http.StatusOK {
+					logger.Error().
+						Str("context", "http.call").
+						Str("method", r.Method).
+						Str("endpoint", endpoint).
+						Int("status", wrapRW.Status()).
+						Str("data", string(requestBody)).
+						Send()
+				}
+			}()
+
+			next.ServeHTTP(wrapRW, r)
+		}
+
+		return http.HandlerFunc(fn)
+	}
+}


### PR DESCRIPTION
## Description
- Add custom middleware for logging to the `chi` router. The custom middleware will catch any `HTTP` errors that do not return 200 OK. This middleware will provide information about the specific handler that caused the error, making it easier to trace.
- Add health check endpoint